### PR TITLE
Allow emulator HTTP access

### DIFF
--- a/app/src/main/java/com/example/musicapplicationse114/di/ApiModule.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/di/ApiModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object ApiModule {
 
-        private const val BASE_URL = "http://127.0.0.1:8082/"
+        private const val BASE_URL = "http://10.0.2.2:8082/"
 //      private const val BASE_URL = "https://6820d3f1259dad2655adb9ff.mockapi.io/"
 
     @Provides

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,5 +2,6 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">172.20.10.2</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- update `network_security_config.xml` to permit emulator connections
- set API base URL to `10.0.2.2` so the Android emulator can reach the backend on the host

## Testing
- `./gradlew test --continue` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6866a9ace5b0832f8b55de55fb8cb186