### PR TITLE
Fix navigation to Profile screen

### DIFF
--- a/app/src/main/java/com/example/musicapplicationse114/Navigation.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/Navigation.kt
@@ -44,6 +44,7 @@ import com.example.musicapplicationse114.ui.screen.home.HomeViewModel
 import com.example.musicapplicationse114.ui.screen.library.LibraryScreen
 import com.example.musicapplicationse114.ui.screen.likedsongs.LikedSongsScreen
 import com.example.musicapplicationse114.ui.screen.login.LoginScreen
+import com.example.musicapplicationse114.ui.screen.profile.ProfileScreen
 import com.example.musicapplicationse114.ui.screen.login.LoginViewModel
 import com.example.musicapplicationse114.ui.screen.playListSongs.PlayListSongsScreen
 import com.example.musicapplicationse114.ui.screen.player.MiniPlayer
@@ -85,6 +86,7 @@ sealed class Screen(val route: String, val title: String) {
     object Playlist : Screen("playlist", "Playlist")
     object CreatePlaylist : Screen("createPlaylist", "Create Playlist")
     object SearchSongAddIntoPlaylist : Screen("searchSongAddIntoPlaylist", "Search Song Add Into Playlist")
+    object Profile : Screen("profile", "Profile")
 
 }
 
@@ -245,6 +247,12 @@ fun Navigation() {
                             sharedViewModel,
                             mainViewModel,
                             artistViewModel
+                        )
+                    }
+                    composable(Screen.Profile.route) {
+                        ProfileScreen(
+                            navController = navController,
+                            mainViewModel = mainViewModel
                         )
                     }
                     composable(

--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/home/HomeScreen.kt
@@ -680,6 +680,7 @@ fun HomeScreen(
                     .size(50.dp)
                     .clickable {
                         Log.d("HomeScreen", "Profile image clicked")
+                        navController.navigate(Screen.Profile.route)
                     }
             )
         }


### PR DESCRIPTION
## Summary
- add `Profile` route in navigation graph
- navigate to `ProfileScreen` from Home avatar image

## Testing
- `sh gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866c29adeb8832fa2126d3aad2e813e