### PR TITLE
Fix navigation to Profile screen

### DIFF
--- a/app/src/main/java/com/example/musicapplicationse114/Navigation.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/Navigation.kt
@@ -44,6 +44,9 @@ import com.example.musicapplicationse114.ui.screen.home.HomeViewModel
 import com.example.musicapplicationse114.ui.screen.library.LibraryScreen
 import com.example.musicapplicationse114.ui.screen.likedsongs.LikedSongsScreen
 import com.example.musicapplicationse114.ui.screen.login.LoginScreen
+import com.example.musicapplicationse114.ui.screen.profile.ProfileScreen
+import com.example.musicapplicationse114.ui.screen.playlists.PlayListViewModel
+import com.example.musicapplicationse114.ui.screen.artists.ArtistsFollowingViewModel
 import com.example.musicapplicationse114.ui.screen.login.LoginViewModel
 import com.example.musicapplicationse114.ui.screen.playListSongs.PlayListSongsScreen
 import com.example.musicapplicationse114.ui.screen.player.MiniPlayer
@@ -85,6 +88,7 @@ sealed class Screen(val route: String, val title: String) {
     object Playlist : Screen("playlist", "Playlist")
     object CreatePlaylist : Screen("createPlaylist", "Create Playlist")
     object SearchSongAddIntoPlaylist : Screen("searchSongAddIntoPlaylist", "Search Song Add Into Playlist")
+    object Profile : Screen("profile", "Profile")
 
 }
 
@@ -247,6 +251,15 @@ fun Navigation() {
                             artistViewModel
                         )
                     }
+                    composable(Screen.Profile.route) {
+                        ProfileScreen(
+                            navController = navController,
+                            mainViewModel = mainViewModel,
+                            homeViewModel = hiltViewModel(),
+                            playlistViewModel = hiltViewModel(),
+                            artistsFollowingViewModel = hiltViewModel()
+                        )
+                    }
                     composable(
                         route = Screen.Artist.route,
                         arguments = listOf(navArgument("artistId") { type = NavType.LongType })
@@ -342,6 +355,7 @@ fun Navigation() {
                                         Screen.Library.route,
                                         Screen.Playlist.route,
                                         Screen.PlaylistSongs.route,
+                                        Screen.Profile.route,
                                         "home?username={username}&timeOfDay={timeOfDay}")) {
                 Column {
                     if (playerState.currentSong != null && !mainViewModel.isFullScreenPlayer.value) {

--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/home/HomeScreen.kt
@@ -680,6 +680,7 @@ fun HomeScreen(
                     .size(50.dp)
                     .clickable {
                         Log.d("HomeScreen", "Profile image clicked")
+                        navController.navigate(Screen.Profile.route)
                     }
             )
         }

--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/ProfileScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,16 +30,34 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.musicapplicationse114.MainViewModel
 import com.example.musicapplicationse114.R
+import com.example.musicapplicationse114.ui.screen.artists.ArtistsFollowingViewModel
+import com.example.musicapplicationse114.ui.screen.home.HomeViewModel
+import com.example.musicapplicationse114.ui.screen.playlists.PlayListViewModel
+import com.example.musicapplicationse114.auth.TokenManager
 import com.example.musicapplicationse114.ui.theme.MusicApplicationSE114Theme
 
 @Composable
 fun ProfileScreen(
-    navController: androidx.navigation.NavController,
-    mainViewModel: MainViewModel
+    navController: NavController,
+    mainViewModel: MainViewModel,
+    homeViewModel: HomeViewModel,
+    playlistViewModel: PlayListViewModel,
+    artistsFollowingViewModel: ArtistsFollowingViewModel
 ) {
+    val homeState by homeViewModel.uiState.collectAsState()
+    val playlistState by playlistViewModel.uiState.collectAsState()
+    val artistState by artistsFollowingViewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        homeViewModel.updateUserName()
+        homeViewModel.loadFavoriteSong()
+        playlistViewModel.loadPlaylist()
+        artistsFollowingViewModel.loadFollowedArtists()
+    }
     Scaffold(
         containerColor = Color.Black,
         bottomBar = {
@@ -109,7 +130,7 @@ fun ProfileScreen(
 
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(
-                    "Logan Jimmy",
+                    homeState.username,
                     color = Color.White,
                     fontWeight = FontWeight.Bold,
                     fontSize = 16.sp
@@ -132,9 +153,21 @@ fun ProfileScreen(
                         .padding(horizontal = 8.dp),
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
-                    ProfileStatBox(icon = Icons.Default.Favorite, value = "120", label = "songs")
-                    ProfileStatBox(icon = Icons.Default.QueueMusic, value = "12", label = "playlists")
-                    ProfileStatBox(icon = Icons.Default.Group, value = "3", label = "artists")
+                    ProfileStatBox(
+                        icon = Icons.Default.Favorite,
+                        value = homeState.likeCount.toString(),
+                        label = "songs"
+                    )
+                    ProfileStatBox(
+                        icon = Icons.Default.QueueMusic,
+                        value = playlistState.playlistCount.toString(),
+                        label = "playlists"
+                    )
+                    ProfileStatBox(
+                        icon = Icons.Default.Group,
+                        value = artistState.followCount.toString(),
+                        label = "artists"
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -217,7 +250,10 @@ fun PreviewProfileScreen() {
     MusicApplicationSE114Theme(darkTheme = true) {
         ProfileScreen(
             navController = rememberNavController(),
-            mainViewModel = MainViewModel()
+            mainViewModel = MainViewModel(),
+            homeViewModel = HomeViewModel(api = null, mainLog = null, tokenManager = null),
+            playlistViewModel = PlayListViewModel(api = null, tokenManager = TokenManager(androidx.compose.ui.platform.LocalContext.current)),
+            artistsFollowingViewModel = ArtistsFollowingViewModel(api = null, tokenManager = null)
         )
     }
 }


### PR DESCRIPTION
## Summary
- add dynamic data loading for profile
- show username and counts from viewmodels
- pass required viewmodels to `ProfileScreen`
- enable bottom nav visibility on profile screen

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6866c29adeb8832fa2126d3aad2e813e