### PR TITLE
Add Edit Profile feature

### DIFF
--- a/app/src/main/java/com/example/musicapplicationse114/Navigation.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/Navigation.kt
@@ -43,6 +43,7 @@ import com.example.musicapplicationse114.ui.screen.library.LibraryScreen
 import com.example.musicapplicationse114.ui.screen.likedsongs.LikedSongsScreen
 import com.example.musicapplicationse114.ui.screen.login.LoginScreen
 import com.example.musicapplicationse114.ui.screen.profile.ProfileScreen
+import com.example.musicapplicationse114.ui.screen.profile.EditProfileScreen
 import com.example.musicapplicationse114.ui.screen.login.LoginViewModel
 import com.example.musicapplicationse114.ui.screen.playListSongs.PlayListSongsScreen
 import com.example.musicapplicationse114.ui.screen.player.MiniPlayer
@@ -88,6 +89,7 @@ sealed class Screen(val route: String, val title: String) {
     object CreatePlaylist : Screen("createPlaylist", "Create Playlist")
     object SearchSongAddIntoPlaylist : Screen("searchSongAddIntoPlaylist", "Search Song Add Into Playlist")
     object Profile : Screen("profile", "Profile")
+    object EditProfile : Screen("editProfile", "Edit Profile")
 
 }
 
@@ -257,6 +259,13 @@ fun Navigation() {
                             homeViewModel = hiltViewModel(),
                             playlistViewModel = hiltViewModel(),
                             artistsFollowingViewModel = hiltViewModel()
+                        )
+                    }
+                    composable(Screen.EditProfile.route) {
+                        EditProfileScreen(
+                            navController = navController,
+                            mainViewModel = mainViewModel,
+                            viewModel = hiltViewModel()
                         )
                     }
                     composable(

--- a/app/src/main/java/com/example/musicapplicationse114/model/UserUpdateRequest.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/model/UserUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.example.musicapplicationse114.model
+
+data class UserUpdateRequest(
+    val username: String,
+    val email: String,
+    val phone: String,
+    val avatar: String?
+)

--- a/app/src/main/java/com/example/musicapplicationse114/repositories/Api.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/repositories/Api.kt
@@ -25,6 +25,8 @@ import com.example.musicapplicationse114.model.SongPlaylistRequest
 import com.example.musicapplicationse114.model.SongResponse
 import com.example.musicapplicationse114.model.UserLoginRequest
 import com.example.musicapplicationse114.model.UserSignUpRequest
+import com.example.musicapplicationse114.model.UserUpdateRequest
+import com.example.musicapplicationse114.model.UserResponse
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -32,6 +34,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.PUT
 import retrofit2.http.Query
 
 interface Api {
@@ -48,6 +51,12 @@ interface Api {
 
     @POST("/register")
     suspend fun register(@Body request: UserSignUpRequest): Response<AuthenticationResponse>
+
+    @PUT("/api/users/me")
+    suspend fun updateProfile(
+        @Header("Authorization") token: String,
+        @Body request: UserUpdateRequest
+    ): Response<UserResponse>
 
 
     //album

--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/EditProfileScreen.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/EditProfileScreen.kt
@@ -1,0 +1,102 @@
+package com.example.musicapplicationse114.ui.screen.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.example.musicapplicationse114.MainViewModel
+import com.example.musicapplicationse114.common.enum.LoadStatus
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditProfileScreen(
+    navController: NavController,
+    viewModel: EditProfileViewModel = hiltViewModel(),
+    mainViewModel: MainViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(uiState.status) {
+        if (uiState.status is LoadStatus.Success) {
+            navController.navigate("profile") {
+                popUpTo("editProfile") { inclusive = true }
+            }
+        }
+    }
+
+    Scaffold { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .padding(innerPadding)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            OutlinedTextField(
+                value = uiState.username,
+                onValueChange = { viewModel.updateUsername(it) },
+                label = { Text("Username") },
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    containerColor = Color(0xFF333333),
+                    unfocusedBorderColor = Color(0xFF333333),
+                    focusedBorderColor = Color(0xFF4169E1)
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = uiState.email,
+                onValueChange = { viewModel.updateEmail(it) },
+                label = { Text("Email") },
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    containerColor = Color(0xFF333333),
+                    unfocusedBorderColor = Color(0xFF333333),
+                    focusedBorderColor = Color(0xFF4169E1)
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = uiState.phone,
+                onValueChange = { viewModel.updatePhone(it) },
+                label = { Text("Phone") },
+                colors = TextFieldDefaults.outlinedTextFieldColors(
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    containerColor = Color(0xFF333333),
+                    unfocusedBorderColor = Color(0xFF333333),
+                    focusedBorderColor = Color(0xFF4169E1)
+                ),
+                modifier = Modifier.fillMaxWidth()
+            )
+            Button(
+                onClick = { viewModel.updateProfile() },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4169E1))
+            ) {
+                Text("Save", color = Color.White, fontSize = 18.sp)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/EditProfileViewModel.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/EditProfileViewModel.kt
@@ -1,0 +1,73 @@
+package com.example.musicapplicationse114.ui.screen.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.musicapplicationse114.common.enum.LoadStatus
+import com.example.musicapplicationse114.model.UserUpdateRequest
+import com.example.musicapplicationse114.repositories.Api
+import com.example.musicapplicationse114.auth.TokenManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class EditProfileState(
+    val username: String = "",
+    val email: String = "",
+    val phone: String = "",
+    val avatar: String = "",
+    val status: LoadStatus = LoadStatus.Init()
+)
+
+@HiltViewModel
+class EditProfileViewModel @Inject constructor(
+    private val api: Api?,
+    private val tokenManager: TokenManager?
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(EditProfileState())
+    val uiState = _uiState.asStateFlow()
+
+    fun updateUsername(username: String) {
+        _uiState.value = _uiState.value.copy(username = username)
+    }
+
+    fun updateEmail(email: String) {
+        _uiState.value = _uiState.value.copy(email = email)
+    }
+
+    fun updatePhone(phone: String) {
+        _uiState.value = _uiState.value.copy(phone = phone)
+    }
+
+    fun updateAvatar(avatar: String) {
+        _uiState.value = _uiState.value.copy(avatar = avatar)
+    }
+
+    fun updateProfile() {
+        viewModelScope.launch {
+            try {
+                _uiState.value = _uiState.value.copy(status = LoadStatus.Loading())
+                val token = tokenManager?.getToken()
+                if (api != null && !token.isNullOrBlank()) {
+                    val result = api.updateProfile(token, UserUpdateRequest(
+                        _uiState.value.username,
+                        _uiState.value.email,
+                        _uiState.value.phone,
+                        _uiState.value.avatar
+                    ))
+                    if (result.isSuccessful) {
+                        tokenManager?.saveUserName(_uiState.value.username)
+                        _uiState.value = _uiState.value.copy(status = LoadStatus.Success())
+                    } else {
+                        _uiState.value = _uiState.value.copy(status = LoadStatus.Error("${'$'}{result.code()}"))
+                    }
+                } else {
+                    _uiState.value = _uiState.value.copy(status = LoadStatus.Error("Token or API null"))
+                }
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(status = LoadStatus.Error(e.message.toString()))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/ProfileScreen.kt
@@ -88,7 +88,7 @@ fun ProfileScreen(
                         modifier = Modifier
                             .clip(RoundedCornerShape(12.dp))
                             .background(Color.DarkGray)
-                            .clickable { /* Edit action */ }
+                            .clickable { navController.navigate("editProfile") }
                             .padding(horizontal = 20.dp, vertical = 10.dp)
                     ) {
                         Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## Summary
- create `UserUpdateRequest` model
- add `updateProfile` API endpoint
- implement `EditProfileViewModel` and `EditProfileScreen`
- update `Navigation` with new screen
- link from `ProfileScreen` to edit profile
- fix color parameters in `EditProfileScreen`

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6866d1de3400832fb31e9f87d4ddf64a