### PR TITLE
Fix profile layout

### DIFF
--- a/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/musicapplicationse114/ui/screen/profile/ProfileScreen.kt
@@ -161,22 +161,25 @@ fun ProfileScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp),
-                    horizontalArrangement = Arrangement.SpaceEvenly
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     ProfileStatBox(
                         icon = Icons.Default.Favorite,
                         value = homeState.likeCount.toString(),
-                        label = "songs"
+                        label = "songs",
+                        modifier = Modifier.weight(1f)
                     )
                     ProfileStatBox(
                         icon = Icons.Default.QueueMusic,
                         value = playlistState.playlistCount.toString(),
-                        label = "playlists"
+                        label = "playlists",
+                        modifier = Modifier.weight(1f)
                     )
                     ProfileStatBox(
                         icon = Icons.Default.Group,
                         value = artistState.followCount.toString(),
-                        label = "artists"
+                        label = "artists",
+                        modifier = Modifier.weight(1f)
                     )
                 }
 
@@ -208,13 +211,13 @@ fun ProfileScreen(
 fun ProfileStatBox(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     value: String,
-    label: String
+    label: String,
+    modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .background(Color(0xFF1A1A1A), RoundedCornerShape(12.dp))
-            .padding(12.dp)
-            .width(90.dp),
+            .padding(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Icon(


### PR DESCRIPTION
## Summary
- make profile stats responsive using `Modifier.weight`
- allow passing `Modifier` into `ProfileStatBox`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd97e680832fbce5e47e7695dc06