### PR TITLE
Add /api prefix for user profile endpoint

### DIFF
--- a/code/be/src/main/java/com/music/application/be/modules/user/UserController.java
+++ b/code/be/src/main/java/com/music/application/be/modules/user/UserController.java
@@ -24,7 +24,8 @@ import java.io.IOException;
 import java.util.List;
 
 @RestController
-@RequestMapping("/users")
+// Support both legacy '/users' paths and new '/api/users' paths
+@RequestMapping({"/users", "/api/users"})
 public class UserController {
 
     private final UserService userService;


### PR DESCRIPTION
## Summary
- allow `UserController` to respond to `/api/users` routes while still supporting old `/users` path

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6866dfdc73f0832f964a85ed98ceb726