### PR TITLE
Add /api users endpoints

### DIFF
--- a/code/be/src/main/java/com/music/application/be/modules/user/UserController.java
+++ b/code/be/src/main/java/com/music/application/be/modules/user/UserController.java
@@ -24,7 +24,8 @@ import java.io.IOException;
 import java.util.List;
 
 @RestController
-@RequestMapping("/users")
+// Support both legacy '/users' paths and new '/api/users' paths
+@RequestMapping({"/users", "/api/users"})
 public class UserController {
 
     private final UserService userService;
@@ -62,6 +63,19 @@ public class UserController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("Failed to fetch profile");
+        }
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUser() {
+        try {
+            UserDetailDTO detail = userService.getCurrentUserDetails();
+            return ResponseEntity.ok(detail);
+        } catch (UsernameNotFoundException | EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("User not authenticated");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Failed to fetch current user");
         }
     }
 

--- a/code/be/src/main/java/com/music/application/be/modules/user/UserService.java
+++ b/code/be/src/main/java/com/music/application/be/modules/user/UserService.java
@@ -68,6 +68,19 @@ public class UserService {
         );
     }
 
+    public UserDetailDTO getCurrentUserDetails() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !(authentication.getPrincipal() instanceof User currentUser)) {
+            throw new UsernameNotFoundException("User not authenticated");
+        }
+
+        User fullUser = userRepository.findById(currentUser.getId())
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        return convertToDetailDTO(fullUser);
+    }
+
     @CacheEvict(value = {"allUsers", "followedArtists", "searchedFollowedArtists"}, allEntries = true)
     public UserDetailDTO updateCurrentUser(UserUpdateDTO userDTO, MultipartFile avatarFile) throws IOException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
## Summary
- support '/api' prefix for user endpoints
- implement GET `/api/users/me` to fetch current user details

## Testing
- `sh gradlew test --no-daemon` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6866dfdc73f0832f964a85ed98ceb726